### PR TITLE
Use https scheme in static request

### DIFF
--- a/volley/templates/base.jinja2
+++ b/volley/templates/base.jinja2
@@ -5,7 +5,7 @@
         <meta charset="utf-8"/>
         <meta content="IE=edge,chrome=1" http-equiv="X-UA-Compatible"/>
         <title>Volley | Game Tracker</title>
-        <link rel="shortcut icon" href="{{ request.static_url('volley:static/volley-16x16.png') }}">
+        <link rel="shortcut icon" href="{{ request.static_url('volley:static/volley-16x16.png',_scheme='https') }}">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.3.1/dist/semantic.min.css">
     {% endblock %}
 </head>
@@ -22,9 +22,9 @@
 
         <a class="header item" href="/">
             <div>
-                <img src="{{ request.static_url('volley:static/volley.png') }}" height="32" width="32"
-                     alt="Volley | Game Tracker"/>
                 Volley
+                <img src="{{ request.static_url('volley:static/volley.png',_scheme='https') }}" height="32" width="32"
+                     alt="Volley | Game Tracker"/>
             </div>
         </a>
 

--- a/volley/templates/base.jinja2
+++ b/volley/templates/base.jinja2
@@ -22,9 +22,9 @@
 
         <a class="header item" href="/">
             <div>
-                Volley
                 <img src="{{ request.static_url('volley:static/volley.png',_scheme='https') }}" height="32" width="32"
                      alt="Volley | Game Tracker"/>
+                Volley
             </div>
         </a>
 

--- a/volley/templates/match_submit.jinja2
+++ b/volley/templates/match_submit.jinja2
@@ -60,4 +60,4 @@
     </div>
 </form>
 
-<script src="{{ request.static_url('volley:static/match_submit.js') }}"></script>
+<script src="{{ request.static_url('volley:static/match_submit.js',_scheme='https') }}"></script>

--- a/volley/templates/match_table.jinja2
+++ b/volley/templates/match_table.jinja2
@@ -42,5 +42,5 @@
     </tfoot>
 </table>
 
-<script src="{{ request.static_url('volley:static/paginathing.js') }}"></script>
-<script src="{{ request.static_url('volley:static/match_table.js') }}"></script>
+<script src="{{ request.static_url('volley:static/paginathing.js',_scheme='https') }}"></script>
+<script src="{{ request.static_url('volley:static/match_table.js',_scheme='https') }}"></script>

--- a/volley/templates/player_table.jinja2
+++ b/volley/templates/player_table.jinja2
@@ -32,9 +32,9 @@
     </tbody>
 </table>
 
-<script src="{{ request.static_url('volley:static/jquery.tablesort.min.js') }}"></script>
+<script src="{{ request.static_url('volley:static/jquery.tablesort.min.js',_scheme='https') }}"></script>
 <script src="https://cdn.jsdelivr.net/npm/d3@5.5.0/dist/d3.min.js"></script>
-<script src="{{ request.static_url('volley:static/player_table.js') }}"></script>
+<script src="{{ request.static_url('volley:static/player_table.js',_scheme='https') }}"></script>
 <script>
     var data = [
         {% for p in players %}

--- a/volley/templates/playerpage.jinja2
+++ b/volley/templates/playerpage.jinja2
@@ -106,8 +106,8 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/d3@5.5.0/dist/d3.min.js"></script>
-    <script src="{{ request.static_url('volley:static/winchance_player_graph.js') }}"></script>
-    <script src="{{ request.static_url('volley:static/skillgraph.js') }}"></script>
+    <script src="{{ request.static_url('volley:static/winchance_player_graph.js',_scheme='https') }}"></script>
+    <script src="{{ request.static_url('volley:static/skillgraph.js',_scheme='https') }}"></script>
     <script>
         winchance_connectivity_data = [
             {{ connectivity_data(team_connectivity) }}
@@ -144,8 +144,8 @@
         skillgraph('#skillgraph', skillgraph_data);
     </script>
 
-    <link rel="stylesheet" href="{{ request.static_url('volley:static/winchance_player_graph.css') }}">
-    <link rel="stylesheet" href="{{ request.static_url('volley:static/skillgraph.css') }}">
+    <link rel="stylesheet" href="{{ request.static_url('volley:static/winchance_player_graph.css',_scheme='https') }}">
+    <link rel="stylesheet" href="{{ request.static_url('volley:static/skillgraph.css',_scheme='https') }}">
 
 
 {% endblock %}


### PR DESCRIPTION
If volley is running behind a reverse proxy and the connection is secured by e.g. a Lets Encrypt certificate, the https scheme should be used. Therefore, I changed the scheme for `request.static` to https. I guess, this might be useful for other people running volley on their own servers behind a reverse proxy. 